### PR TITLE
Feature/intro

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,46 @@ cmake-build-debug/
 
 # Build Directories for Windows
 SFML-2.5.0-win64/
+
+# Created by https://www.gitignore.io/api/c++
+
+### C++ ###
+# Prerequisites
+*.d
+
+# Compiled Object files
+*.slo
+*.lo
+*.o
+*.obj
+
+# Precompiled Headers
+*.gch
+*.pch
+
+# Compiled Dynamic libraries
+*.so
+*.dylib
+*.dll
+
+# Fortran module files
+*.mod
+*.smod
+
+# Compiled Static libraries
+*.lai
+*.la
+*.a
+*.lib
+
+# Executables
+*.exe
+*.out
+*.app
+
+
+# End of https://www.gitignore.io/api/c++
+
+# Ignore the executable file
+nomb
+

--- a/Game.cpp
+++ b/Game.cpp
@@ -1,7 +1,7 @@
 /*
  * Game.cpp
- * Much code taken from SFML tutorials on SFML site.  Basic 
- * flow tutorial at 
+ * Much code taken from SFML tutorials on SFML site.  Basic
+ * flow tutorial at
  * from https://maksimdan.gitbooks.io/sfml-and-gamedevelopement/content/game_class.html
  *
  * You will need to read SFML API and other documentation to understand this code
@@ -23,7 +23,7 @@
  * initial state of shared variables.
  */
 Game::Game(){
-	// Creates the window.  We are using the same window for 
+	// Creates the window.  We are using the same window for
 	// the intro screen as the game, though this can change.
 	window.create(sf::VideoMode(WIDTH, HEIGHT + 100), "Not on my block.");
 	// when done is true we quit
@@ -43,78 +43,18 @@ Game::Game(){
  */
 
 int Game::start(){
-	intro::Intro i;
-	i.show(window);
+  // Build our game intro
+  intro::Intro i;
 
-	window.clear();
-	sf::Texture splash;
-	if(!splash.loadFromFile("./images/neighborhood.png")){
-		std::cerr << "Can't load start image." << std::endl;
-	}
-	sf::Sprite sprite;
-	sprite.setTexture(splash);
+  // Build our window context and pass the ref
+  auto intro_window = i.construct_window_context(800, 600, "Video Games, OH YEAH");
 
-	sf::Font font;
-	if(!font.loadFromFile("fonts/Notable-Regular.ttf")){
-		return EXIT_FAILURE;
-	}
-
-	sf::Text title;
-	title.setFont(font);
-	title.setString("Not on my block.");
-	title.setCharacterSize(64);
-	title.setFillColor(sf::Color::White);
-	title.setPosition(10,200);
-
-	sf::Text text;
-	text.setFont(font);
-	text.setString("(Press Enter to continue)");
-	text.setCharacterSize(24);
-	text.setFillColor(sf::Color::White);
-	text.setPosition(150, 350); 
-
-	sf::Clock clock;
-
-	sf::Music music;
-	if(!music.openFromFile("music/epic_hero.wav")){
-		return EXIT_FAILURE;
-	}
-
-	music.play();
-	while (window.isOpen())
-	{
-		sf::Event event;
-		while (window.pollEvent(event))
-		{
-			if (event.type == sf::Event::Closed){
-				window.close();
-				music.stop();
-				exit(0);
-			}
-
-			if(event.type == sf::Event::KeyPressed){
-				if(event.key.code == sf::Keyboard::Return){
-					window.clear();
-					music.stop();
-					return 0;
-				}
-			}
-
-		}
-
-		window.draw(sprite);
-		window.draw(title);
-		window.draw(text);
-		window.display();
-
-		sf::Time time = clock.getElapsedTime();
-		sf::Int32 mills = time.asMilliseconds();
-		if(mills % 1000 > 500){
-			text.setFillColor(sf::Color::Black);
-		} else {
-			text.setFillColor(sf::Color::White);
-		}
-	}
+  // Deref our window and show it
+  int running = i.show(*intro_window);
+  if (running < 0) {
+    std::cerr << "Oh man the intro screen broke :(" << std::endl;
+    return EXIT_FAILURE;
+  }
 
 	return 0;
 }
@@ -148,7 +88,7 @@ void Game::run()
 	music.stop();
 }
 
-/* 
+/*
  * All game events such as keypresses are handled
  * here.
  */
@@ -181,7 +121,7 @@ void Game::processEvents()
 					break;
 					default:
 					break;
-				}				
+				}
 			default:
 				break;
 		}

--- a/Intro.cpp
+++ b/Intro.cpp
@@ -1,15 +1,11 @@
 #include <iostream>
 #include "Intro.hpp"
+#include "WindowLoader.hpp"
 #include "SFML/Audio.hpp"
 
 namespace intro {
   Intro::Intro(int width, int height, sf::Font font) {
-    this->FONT = font;
-
-    window.create(sf::VideoMode(width, height + 100), "Not on my block");
-
-    loaded = false;
-
+    window.create(sf::VideoMode(width, height + 100), "SHOOPOPOPOP");
   }
 
   int Intro::show(sf::RenderWindow& window) {
@@ -46,22 +42,35 @@ namespace intro {
 
     sf::Music music;
 
-        // TODO - This currently breaks.
-//        sf::SoundBuffer sound_buffer;
-//        if (!sound_buffer.loadFromFile("music/epic_hero.wav")) {
-//            text.setFillColor(sf::Color::Black);
-//        } else {
-//            text.setFillColor(sf::Color::White);
-//        }
-
     float seconds = 0.0f;
-    while (seconds <= 5.0f) {
+    /* while (seconds <= 5.0f) { */
+    /*   window.draw(sprite); */
+    /*   window.draw(title); */
+    /*   window.draw(text); */
+    /*   window.display(); */
+
+    /*   seconds = clock.getElapsedTime().asSeconds(); */
+    /* } */
+    while (window.isOpen()) {
+      sf::Event event;
+      while (window.pollEvent(event)) {
+        if (event.type = sf::Event::Closed) {
+          window.close();
+          exit(0);
+        }
+
+        if (event.type == sf::Event::KeyPressed) {
+          if(event.key.code == sf::Keyboard::Return) {
+            window.clear();
+            return 0;
+          }
+        }
+      }
+
       window.draw(sprite);
       window.draw(title);
       window.draw(text);
       window.display();
-
-      seconds = clock.getElapsedTime().asSeconds();
     }
   }
 } // namespace intro

--- a/Intro.cpp
+++ b/Intro.cpp
@@ -4,8 +4,16 @@
 #include "SFML/Audio.hpp"
 
 namespace intro {
-  Intro::Intro(int width, int height, sf::Font font) {
-    window.create(sf::VideoMode(width, height + 100), "SHOOPOPOPOP");
+  sf::RenderWindow* Intro::construct_window_context(
+      int width = 800,
+      int height = 600,
+      std::string heading = "Video Games, OH YEAH"
+      ) {
+    this->rw.create(sf::VideoMode(width, height), heading);
+
+    auto window_copy = &this->rw;
+
+    return window_copy;
   }
 
   int Intro::show(sf::RenderWindow& window) {
@@ -20,7 +28,7 @@ namespace intro {
     sprite.setTexture(spash);
 
     sf::Font font;
-    if (!font.loadFromFile("./fonts/COMIC.ttf")) {
+    if (!font.loadFromFile("fonts/Notable-Regular.ttf")) {
       return EXIT_FAILURE;
     }
 
@@ -42,21 +50,12 @@ namespace intro {
 
     sf::Music music;
 
-    float seconds = 0.0f;
-    /* while (seconds <= 5.0f) { */
-    /*   window.draw(sprite); */
-    /*   window.draw(title); */
-    /*   window.draw(text); */
-    /*   window.display(); */
-
-    /*   seconds = clock.getElapsedTime().asSeconds(); */
-    /* } */
     while (window.isOpen()) {
       sf::Event event;
       while (window.pollEvent(event)) {
-        if (event.type = sf::Event::Closed) {
+        if (event.type == sf::Event::Closed) {
           window.close();
-          exit(0);
+          return 0;
         }
 
         if (event.type == sf::Event::KeyPressed) {
@@ -71,7 +70,18 @@ namespace intro {
       window.draw(title);
       window.draw(text);
       window.display();
+
+
+      sf::Time time = clock.getElapsedTime();
+      sf::Int32 mills = time.asMilliseconds();
+      if(mills % 1000 > 500){
+        text.setFillColor(sf::Color::Black);
+      } else {
+        text.setFillColor(sf::Color::White);
+      }
     }
+
+    return 0;
   }
 } // namespace intro
 

--- a/include/Intro.hpp
+++ b/include/Intro.hpp
@@ -4,6 +4,7 @@
 
 namespace intro {
   class Intro {
+    sf::RenderWindow rw;
     public:
       Intro() = default;
       Intro(int, int, sf::Font);

--- a/include/Intro.hpp
+++ b/include/Intro.hpp
@@ -1,15 +1,16 @@
 #ifndef INCLUDE_INTRO_HPP
 #define INCLUDE_INTRO_HPP
 #include "SFML/Graphics.hpp"
+#include <string>
 
 namespace intro {
   class Intro {
     sf::RenderWindow rw;
     public:
       Intro() = default;
-      Intro(int, int, sf::Font);
       ~Intro() = default;
       int show(sf::RenderWindow&);
+      sf::RenderWindow* construct_window_context(int, int, std::string);
   };
 } // namespace intro
 

--- a/main.cpp
+++ b/main.cpp
@@ -1,3 +1,4 @@
+#include <iostream>
 #include "SFML/Graphics.hpp"
 #include "Intro.hpp"
 #include "Game.hpp"
@@ -5,7 +6,11 @@
 int main(int argc, char** argv){
 	Game g;
 	while(true){
-		g.start();
+		int started = g.start();
+    if (started  < 0) {
+      std::cerr << "Error! Game failed to start" << std::endl;
+      break;
+    }
 		g.run();
 	}
 }


### PR DESCRIPTION
## What does this PR do?
This adds some sauce to the .gitignore for things like idea editor output etc. This also fixes some compiler errors and now safely uses the WindowLoader class to handle window state as well as state transitions from title to main game. This functionality can now be extended to all other screens via function instantiation. 

## How to use the window loader class
First, create a function within your class that returns a reference to a `sf::RenderWIndow` object. With this, we can pass it down to the WindowLoader object to keep a consistent window state.

Second, pass the window instance around as needed.

### This version DOES COMPILE NOW (sorry about that)